### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           CI: true
       - name: Publish Docker
-        uses: elgohr/Publish-Docker-Github-Action@1.12
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: lachouettecoop/api
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore